### PR TITLE
make_vcsp_2018.py: Fixed uninitialzied variable

### DIFF
--- a/python/make_vcsp_2018.py
+++ b/python/make_vcsp_2018.py
@@ -419,7 +419,7 @@ def make_vcsp_s3(lib_name, lib_path, skip_cert):
     update_items_json = False
 
     response = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=lib_folder_path, Delimiter="/")
-    if response['CommonPrefixes']:
+    if 'CommonPrefixes' in response:
         # skip items generation if no child folders
         for child in response['CommonPrefixes']:
             p = child['Prefix']

--- a/python/make_vcsp_2018.py
+++ b/python/make_vcsp_2018.py
@@ -127,6 +127,7 @@ def _dir2item(path, directory, md5_enabled, lib_id):
     vcsp_type = VCSP_TYPE_OTHER
     folder = ""
     folder_md5 = ""
+    is_vapp = ""
     for f in os.listdir(path):
         if f == ".DS_Store" or f == ''.join((directory, os.extsep, FORMAT)):
             continue


### PR DESCRIPTION
I ran into the following error when I tried to run the script on a local directory:
```
vghetto-scripts/python$ python make_vcsp_2018.py -n content-library-test -t local --path /usr/local/src/ace/content-library-test
Traceback (most recent call last):
  File "make_vcsp_2018.py", line 578, in <module>
    main()
  File "make_vcsp_2018.py", line 573, in main
    make_vcsp(lib_name, lib_path, md5_enabled)
  File "make_vcsp_2018.py", line 298, in make_vcsp
    item_json = _dir2item(p, item_path, md5_enabled, "urn:uuid:%s" % lib_id)
  File "make_vcsp_2018.py", line 163, in _dir2item
    return _make_item(name, vcsp_type, name, files_items, identifier = uuid.uuid4(), library_id=lib_id, is_vapp_template=is_vapp)
UnboundLocalError: local variable 'is_vapp' referenced before assignment
```

The PR should fix the issue.