### PR TITLE
Added AWS Lambda support

### DIFF
--- a/python/make_vcsp_2018.py
+++ b/python/make_vcsp_2018.py
@@ -344,7 +344,7 @@ def make_vcsp(lib_name, lib_path, md5_enabled):
         json.dump(_make_items(items, lib_version), f, indent=2)
 
 
-def make_vcsp_s3(lib_name, lib_path, skip_cert):
+def make_vcsp_s3(lib_name, lib_path, skip_cert, aws_default_region = None):
     """
     lib_path is the library folder path on the bucket with pattern: [bucket-name]/[object-folder-path]
 
@@ -371,7 +371,10 @@ def make_vcsp_s3(lib_name, lib_path, skip_cert):
     lib_folder_path = paths[1]
 
     s3 = boto3.resource("s3")
-    s3_client = boto3.client('s3')
+    if aws_default_region is None:
+        s3_client = boto3.client('s3')
+    else:
+        s3_client = boto3.client('s3',region_name=aws_default_region)
 
     # check if the given s3 bucket exists
     try:

--- a/python/sample_lambda_function_for_make_vcsp_2018.py
+++ b/python/sample_lambda_function_for_make_vcsp_2018.py
@@ -1,0 +1,39 @@
+import json
+import make_vcsp_2018
+
+def lambda_handler(event, context):
+    buf = 'Lambda Content Library Handler. '
+    try:
+        buf = buf + "Event triggered by file: " + event["Records"][0]["s3"]["object"]["key"]
+    except:
+        print("No event key found.")
+        buf = buf + " No S3 event key found."
+        return {
+            'statusCode': 200,
+            'body': buf
+        }
+
+    # If we don't filter out .json files, this script keeps firing in a loop.
+    # We don't want the script to fire again when the script itself writes JSON files to the bucket.
+    # You could also solve this problem by using a suffix filter in the S3 trigger configuration,
+    # but you can only have one suffix per trigger. You would have to create a trigger for every
+    # possible filetype that might get uploaded to the bucket. 
+    filename = (event["Records"][0]["s3"]["object"]["key"]).lower()
+    if filename[-5:] == ".json":
+        filter_status = "filtered"
+    else:
+        # Example usage: make_vcsp_2018.make_vcsp_s3('my-library','library-bucket/lib1',False,'us-east-2')
+        # Argument description:
+        # my-library - name of the library, 
+        # library-bucket/lib1 -  S3 bucket name and folder name
+        # false - Flag configured not to skip SSL validation
+        # us-east-2 - default region
+        # We pass the default region directly to the boto library so we don't have to configure environment variables in Lambda
+        make_vcsp_2018.make_vcsp_s3('REPLACE-ME','REPLACE-ME',False,'REPLACE-ME')
+        filter_status = "unfiltered"
+    
+    return {
+        'statusCode': 200,
+        'body': buf,
+        'filterStatus': filter_status
+    }


### PR DESCRIPTION
This change introduces Lambda support. The original script requires AWS CLI configuration, which you can do in Lambda. But you can save yourself unnecessary work configuring AWS CLI in Lambda by simply passing a default region to the boto3 library.

This change adds an optional aws_default_region argument to the make_vcsp_s3() function. It also includes a sample Lambda function that invokes the make_vcsp_s3() function.

Signed-off-by: Patrick Kremer <kremerpt@amazon.com>