### PR TITLE
Recognise .ova type as VCSP_TYPE_OVF

### DIFF
--- a/python/make_vcsp_2015.py
+++ b/python/make_vcsp_2015.py
@@ -101,7 +101,7 @@ def _dir2item(path, directory, md5_enabled):
                 folder = new_folder
             if md5_enabled:
                 m.update(os.path.dirname(p).encode('utf-8'))
-            if ".ovf" in p:
+            if ".ovf" in p or ".ova" in p:
                 vcsp_type = "vcsp.ovf"
             size = os.path.getsize(p)
             href = "%s/%s" % (directory, f)

--- a/python/make_vcsp_2018.py
+++ b/python/make_vcsp_2018.py
@@ -143,7 +143,7 @@ def _dir2item(path, directory, md5_enabled, lib_id):
                 folder = new_folder
             if md5_enabled:
                 m.update(os.path.dirname(p).encode('utf-8'))
-            if ".ovf" in p:
+            if ".ovf" in p or ".ova" in p:
                 vcsp_type = VCSP_TYPE_OVF
                 # TODO: ready ovf descriptor for type metadata
                 is_vapp = "false"
@@ -195,7 +195,7 @@ def _dir2item_s3(s3_client, bucket_name, path, item_name, skip_cert, lib_id, old
         if file_path == path or file_path.endswith("item.json"):
             continue
         file_name = file_path.split("/")[-1]
-        if ".ovf" in file_name:
+        if ".ovf" in file_name or ".ova" in file_name:
             vcsp_type = VCSP_TYPE_OVF
             # check if the existing item json already contains "type-metadata" metadata, if not
             # download the OVF file and parse the descriptor for metadata and search for "<VirtualSystemCollection"

--- a/python/make_vcsp_2022.py
+++ b/python/make_vcsp_2022.py
@@ -151,7 +151,7 @@ def _dir2item(path, directory, md5_enabled, lib_id):
                 folder = new_folder
             if md5_enabled:
                 m.update(os.path.dirname(p).encode('utf-8'))
-            if ".ovf" in p:
+            if ".ovf" in p or ".ova" in p:
                 vcsp_type = VCSP_TYPE_OVF
                 # TODO: ready ovf descriptor for type metadata
                 is_vapp = "false"
@@ -203,7 +203,7 @@ def _dir2item_s3(s3_client, bucket_name, path, item_name, skip_cert, lib_id, old
         if file_path == path or file_path.endswith("item.json"):
             continue
         file_name = file_path.split("/")[-1]
-        if ".ovf" in file_name:
+        if ".ovf" in file_name or ".ova" in file_name:
             vcsp_type = VCSP_TYPE_OVF
             # check if the existing item json already contains "type-metadata" metadata, if not
             # download the OVF file and parse the descriptor for metadata and search for "<VirtualSystemCollection"


### PR DESCRIPTION
**Fix Description**
`.ova` file type is being tagged as `vcsp.other` in the generated item metadata json files (items.json, item.json), so when a subscribed content library is created in vCenter, the `.ova` type of items show up in the "Other Templates" tab instead of being in "OVF & OVA Templates" tab. This fix tags the `.ova` type correctly with `VCSP_TYPE_OVF`.




**Testing Done:**
1. Created below directory structure with two ova files
```
test-lib
├── nostalgia-signed
│   └── notalgia-signed.ova
└── nostalgia-signed-1
    └── notalgia-signed-1.ova
```

2. Generated vcsp library
```
python3 make_vcsp_2018.py --name third-party-lib --path test-lib
```

3. Verified that generated item metadata files have type field as `vcsp.ovf`
E.g. items.json
```
{
  "items": [
    {
      ...
      "name": "nostalgia-signed-1",
      "type": "vcsp.ovf"
    },
    {
      ...
      "name": "nostalgia-signed",
      "type": "vcsp.ovf"
    }
  ]
}
```

4. Created a subscriber library in VC with generated lib.json subscription url. Verified that items are displaying under OVF & OVA Templates tab
![Screenshot 2024-08-01 at 3 42 28 PM](https://github.com/user-attachments/assets/75561c8b-3b58-4b49-83a6-919f4dbedb56)


